### PR TITLE
Linux test fix & get_position impl.

### DIFF
--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -13,9 +13,9 @@ type WINDOW = c_int;
 fn xdo_translate_key(key: &Keys) -> c_int {
     match key {
         Keys::LEFT => 1,
-        Keys::MIDDLE => 2,
+        Keys::WHEEL | Keys::MIDDLE => 2,
         Keys::RIGHT => 3,
-        _ => panic!("Invalid key passed")
+        _ => panic!("Invalid key passed: {:?}", key)
     }
 }
 

--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -9,6 +9,7 @@ use std::{ptr};
 
 type XDO = *const c_void;
 type WINDOW = c_int;
+type INTPTR = *mut c_int;
 
 fn xdo_translate_key(key: &Keys) -> c_int {
     match key {
@@ -16,6 +17,15 @@ fn xdo_translate_key(key: &Keys) -> c_int {
         Keys::WHEEL | Keys::MIDDLE => 2,
         Keys::RIGHT => 3,
         _ => panic!("Invalid key passed: {:?}", key)
+    }
+}
+
+impl From<(c_int, c_int)> for Point {
+    fn from(other: (c_int, c_int)) -> Point {
+        Point {
+            x: other.0 as _,
+            y: other.1 as _,
+        }
     }
 }
 
@@ -32,6 +42,7 @@ extern "C" {
     fn xdo_mouse_down(xdo: XDO, window: WINDOW, button: c_int);
     fn xdo_mouse_up(xdo: XDO, window: WINDOW, button: c_int);
     fn xdo_click_window(xdo: XDO, window: WINDOW, button: c_int);
+    fn xdo_get_mouse_location(xdo: XDO, x: INTPTR, y: INTPTR, screen_num: INTPTR);
 }
 
 impl Mouse {
@@ -64,7 +75,16 @@ impl Mouse {
     }
 
     pub fn get_position(&self) -> Result<Point, Box<dyn Error>> {
-        unimplemented!()
+        let pos: Point;
+        unsafe {
+            let mut x: c_int = 0;
+            let mut y: c_int = 0;
+            let mut _screen_num: c_int = 0;
+            xdo_get_mouse_location(self.xdo, &mut x as INTPTR, &mut y as INTPTR, &mut _screen_num as INTPTR);
+            pos = (x, y).into();
+        }
+
+        Ok(pos)
     }
 
     pub fn wheel(&self, mut delta: i32) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/sys/macos.rs
+++ b/src/sys/macos.rs
@@ -95,7 +95,7 @@ impl Mouse {
     pub fn release<'a>(&self, button: &'a Keys) -> Result<(), Box<dyn error::Error + 'a>> {
         let (event_type, mouse_button) = match button {
             Keys::LEFT => Ok((CGEventType::LeftMouseUp, CGMouseButton::Left)),
-            Keys::MIDDLE => Ok((CGEventType::OtherMouseUp, CGMouseButton::Center)),
+            Keys::WHEEL | Keys::MIDDLE => Ok((CGEventType::OtherMouseUp, CGMouseButton::Center)),
             Keys::RIGHT => Ok((CGEventType::RightMouseUp, CGMouseButton::Right)),
             _ => Err(Box::new(Error::InvalidButtonStr(""))),
         }?;

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -30,6 +30,9 @@ fn win_translate_key(key: (&Keys, &Keys)) -> i32 {
         (Keys::DOWN, Keys::MIDDLE) => MOUSEEVENTF_MIDDLEDOWN,
         (Keys::UP, Keys::MIDDLE) => MOUSEEVENTF_MIDDLEUP,
 
+        (Keys::DOWN, Keys::WHEEL) => MOUSEEVENTF_MIDDLEDOWN,
+        (Keys::UP, Keys::WHEEL) => MOUSEEVENTF_MIDDLEUP,
+
         (Keys::DOWN, Keys::X) => MOUSEEVENTF_XDOWN,
         (Keys::UP, Keys::X) => MOUSEEVENTF_XUP,
         _ => panic!("Invalid parameter passed, please use constants from types::keys"),

--- a/src/types/keys.rs
+++ b/src/types/keys.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub enum Keys {
     LEFT,
     RIGHT,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -8,7 +8,6 @@ mod mouse {
         let mouse = Mouse::new();
         mouse.move_to(500, 500);
         let pos = mouse.get_position().unwrap();
-        assert!(pos.x == 500);
         mouse.press(&Keys::RIGHT).expect("Unable to press button");
         mouse.release(&Keys::RIGHT).expect("Something went wrong");
         mouse.click(&Keys::WHEEL).expect("Something went wrong");

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -7,6 +7,8 @@ mod mouse {
     fn move_and_press() {
         let mouse = Mouse::new();
         mouse.move_to(500, 500);
+        let pos = mouse.get_position().unwrap();
+        assert!(pos.x == 500);
         mouse.press(&Keys::RIGHT).expect("Unable to press button");
         mouse.release(&Keys::RIGHT).expect("Something went wrong");
         mouse.click(&Keys::WHEEL).expect("Something went wrong");


### PR DESCRIPTION
Keys::WHEEL should be the same as Keys::MIDDLE on Linux (would panic otherwise)
Also hooked up the get_position with xdo on Linux. Was previously `unimplemented`