### PR TITLE
Added Install Instructions for Other Distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,22 @@ For more information please visit the [docs](https://docs.rs/mouse-rs/*/mouse_rs
 ## Linux disclaimer
 If you're running into problems building on linux you need to install libxdo-dev.
 
-#### Ubuntu
+#### Debian-based
 ```bash
 sudo apt-get install libxdo-dev
+```
+
+### Arch
+```bash
+sudo pacman -Sy xdotool
+```
+
+### Fedora
+```bash
+sudo dnf install libX11-devel libxdo-devel
+```
+
+### Gentoo
+```bash
+sudo emerge xdotool
 ```


### PR DESCRIPTION
Since I had to look a little to find the Gentoo equivalent of libxdo-dev, I just added the installation instructions for some other distros.

I'm unsure if libx11-devel is necessary for Fedora, though I included it just in case. I only tested the Gentoo one, though I'm confident the others will work.