### PR TITLE
Point struct usize->i32

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -3,8 +3,8 @@ use std::fmt;
 pub mod keys;
 
 pub struct Point {
-    pub x: usize,
-    pub y: usize,
+    pub x: i32,
+    pub y: i32,
 }
 
 impl fmt::Debug for Point {


### PR DESCRIPTION
Use same integer type on move_to and get_position to improve ease of use.
As suggested in #8