### PR TITLE
Added call to xdo_free on drop to not leak xdo struct and more specifically display

### DIFF
--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -37,6 +37,7 @@ pub struct Mouse {
 #[link(name = "xdo")]
 extern "C" {
     fn xdo_new(display: *const c_char) -> XDO;
+    fn xdo_free(xdo: XDO);
 
     fn xdo_move_mouse(xdo: XDO, x: c_int, y: c_int, screen: c_int) -> c_int;
     fn xdo_mouse_down(xdo: XDO, window: WINDOW, button: c_int);
@@ -100,5 +101,13 @@ impl Mouse {
             }
         }
         Ok(())
+    }
+}
+
+impl Drop for Mouse {
+    fn drop(&mut self) {
+        unsafe { 
+            xdo_free(self.xdo); 
+        }
     }
 }


### PR DESCRIPTION
Hey! 

Found a, for me, minor issue with the library allocating memory and opening displays but never freeing the memory or closing the displays on X11.

I added a binding for the xdo_free function and implemented the Drop trait for the Mouse on Linux so that xdo_free is called when the Mouse struct goes out of scope.

