### PR TITLE
fix issue 25: mouse coordinates are always returned as 0 in release building mode

### DIFF
--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -113,7 +113,7 @@ impl Mouse {
     pub fn get_position(&self) -> Result<Point, Box<dyn std::error::Error>> {
         let mut pos: POINT = POINT { x: 0, y: 0 };
         unsafe {
-            let get_cursor_pos: libloading::Symbol<unsafe extern "C" fn(lp_point: &POINT) -> bool> =
+            let get_cursor_pos: libloading::Symbol<unsafe extern "C" fn(lp_point: &mut POINT) -> bool> =
                 self.user32.get(b"GetCursorPos")?;
             get_cursor_pos(&mut pos);
             Ok(pos.into())


### PR DESCRIPTION
The parameter `lp_point` in `get_cursor_pos` should be of reference type `&mut`. I've manually tested and verified it in my local environment.
Fix #25 
Please merge this PR and release a new version. 